### PR TITLE
Changing the URL to the new data repository

### DIFF
--- a/retrieve_external/peeringdb.py
+++ b/retrieve_external/peeringdb.py
@@ -5,7 +5,7 @@ class PeeringdbRetriever(AbstractRetriever):
     def get(self):
         urls = []
         for day in self.days:
-            url = 'http://data.caida.org/datasets/peeringdb-v2/{year}/{month:02d}/peeringdb_2_dump_{year}_{month:02d}_{day:02d}.json'.format(year=day.year, month=day.month, day=day.day)
+            url = 'https://publicdata.caida.org/datasets/peeringdb/{year}/{month:02d}/peeringdb_2_dump_{year}_{month:02d}_{day:02d}.json'.format(year=day.year, month=day.month, day=day.day)
             print(url)
             info = DownloadInfo(url, self.newfilename(url), auth=self.auth)
             urls.append(info)


### PR DESCRIPTION
CAIDA's public data repository has had some minor changes. In the future, PeeringDB data will be available in the new URL.