### PR TITLE
Support for downloading public CAIDA traceroutes

### DIFF
--- a/retrieve_external/abstract_retriever.py
+++ b/retrieve_external/abstract_retriever.py
@@ -44,6 +44,9 @@ class AbstractRetriever(ABC):
         return len(content)
 
     def parallel_download(self, urls):
+        if not urls:
+            print('No files found to download')
+            return
         totalsize = 0
         pb = Progress(len(urls), 'Downloading files',
                       callback=lambda: 'Size {}'.format(format_size(totalsize)))

--- a/retrieve_external/publictraceroute.py
+++ b/retrieve_external/publictraceroute.py
@@ -1,0 +1,56 @@
+import datetime
+import sys
+
+from retrieve_external.caidatraceroute import TType, CaidaTraceroute
+
+
+class PublicTraceroute(CaidaTraceroute):
+    PREFIX_BASE_URL = "https://publicdata.caida.org/datasets/topology/ark/ipv4/prefix-probing"
+    TEAM_BASE_URL = "https://publicdata.caida.org/datasets/topology/ark/ipv4/probe-data"
+
+    def __init__(self, args):
+        super().__init__(args)
+        now = datetime.datetime.now()
+        # Publishing seems to happen at the end of the month
+        last_public_day = datetime.datetime(now.year - 1, now.month, 1)
+        last_public_day -= datetime.timedelta(days=1)
+        orig_days = len(self.days)
+        self.days = [d for d in self.days if d <= last_public_day]
+        print(f"Estimated last day of public traces: {last_public_day}")
+        if not self.days:
+            print("Traceroutes for the target period are not public yet!")
+        if self.days and orig_days > len(self.days):
+            print("Some traceroues in the target period are not public yet.")
+            print(f"Will download public traceroutes between {min(self.days)} and {max(self.days)}")
+
+    def get_prefix(self):
+        for day in self.days:
+            url = f"{PublicTraceroute.PREFIX_BASE_URL}/{day.year}/{day.month:02d}/"
+            regex = f".*{day.year}{day.month:02d}{day.day:02d}.*.warts.gz"
+            yield url, regex
+
+    def get_team(self):
+        for day in self.days:
+            for team in range(1, 4):
+                path = f"team-{team}/{day.year}/cycle-{day.year}{day.month:02d}{day.day:02d}/"
+                url = f"{PublicTraceroute.TEAM_BASE_URL}/{path}"
+                yield url, r".*\.warts\.gz"
+
+
+def get(args, ttype):
+    pt = PublicTraceroute(args)
+    if ttype == TType.team:
+        urls = pt.get(pt.get_team())
+    elif ttype == TType.prefix:
+        urls = pt.get(pt.get_prefix())
+    else:
+        raise ValueError(f"Invalid trace type: {ttype}")
+    pt.parallel_download(urls)
+
+
+def get_publicteam(args):
+    get(args, TType.team)
+
+
+def get_publicprefix(args):
+    get(args, TType.prefix)

--- a/retrieve_external/retrieve.py
+++ b/retrieve_external/retrieve.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 
 from retrieve_external import bgpribs, rirdelegations, relationships, peeringdb, pch
 from retrieve_external.caidatraceroute import get_caidateam, get_caidaprefix
+from retrieve_external import publictraceroute
 
 def main():
     parser = ArgumentParser()
@@ -20,6 +21,12 @@ def main():
 
     caidap = sub.add_parser('caida-prefix', help='Retrieve the CAIDA prefix probing traceroutes.')
     caidap.set_defaults(func=get_caidaprefix)
+
+    publict = sub.add_parser('public-team', help='Retrieve the public CAIDA team probing traces')
+    publict.set_defaults(func=publictraceroute.get_publicteam)
+
+    publicp = sub.add_parser('public-prefix', help='Retrieve the public CAIDA prefix probing traces')
+    publicp.set_defaults(func=publictraceroute.get_publicprefix)
 
     bgp = sub.add_parser('bgp', help='Retrieve bgp RIBs from RouteViews and RIPE RIS.')
     bgp.set_defaults(func=bgpribs.get)


### PR DESCRIPTION
Add a `PublicTraceroute` class and command-line paramters similar to
`CaidaTraceroute` class to download public CAIDA traces.